### PR TITLE
Refactor cart view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,24 @@
 @import "bootstrap";
 @import "custom";
+
+.cart_image{
+  width: 3em;
+  height: 4em;
+}
+
+.checkout{
+  text-align: right;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.total{
+  text-align: right;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h2{
+  text-align: center;
+  font-size: 3em;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,4 +4,12 @@ module ApplicationHelper
     raw("#{link_to("Login", login_path, options)}<br/>\n#{link_to("Create new account", new_user_path, options)}")
   end
 
+  def user_name_possessive
+    if current_user
+      current_user.first_name + "'s"
+    else
+      "Your"
+    end
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+
+  def login_tags(options = {})
+    raw("#{link_to("Login", login_path, options)}<br/>\n#{link_to("Create new account", new_user_path, options)}")
+  end
+
 end

--- a/app/helpers/cart_helper.rb
+++ b/app/helpers/cart_helper.rb
@@ -1,0 +1,12 @@
+module CartHelper
+  include ApplicationHelper
+
+  def checkout_tag(options = {})
+    if current_user
+      link_to("Checkout", new_order_path, options)
+    else
+      login_tags(options)
+    end
+  end
+
+end

--- a/app/views/carts/_item.html.erb
+++ b/app/views/carts/_item.html.erb
@@ -1,0 +1,12 @@
+<div class="item-<%= item.id %>">
+  <tr>
+    <td scope="row"><strong><%= link_to item.title, item_path(item) %></strong></td>
+    <td><%= image_tag item.image, :class => "cart_image"%></td>
+    <td>$<%= item.price %></td>
+    <td><%= quantity %></td>
+    <td><%= link_to "-", cart_path(id: item.id, condition: "decrease"), action: :update, method: :patch, class: "badge badge-danger" %></td>
+    <td><%= link_to "+", cart_path(id: item.id, condition: "increase"), action: :update, method: :patch, class: "badge badge-success" %></td>
+    <td><%= link_to "Remove", cart_path(id: item.id), method: :delete, class: "badge badge-danger" %></td>
+    <td>$<%= quantity * item.price %></td>
+  </tr>
+</div>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,26 +1,3 @@
-<style>
-.cart_image{
-  width: 3em;
-  height: 4em;
-}
-
-      .checkout{
-        text-align: right;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-      .total{
-        text-align: right;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-      h2{
-        text-align: center;
-        font-size: 3em;
-      }
-</style>
 <div class="container">
   <% if current_user  %>
     <h3> <%= current_user.first_name %>'s  Cart</h3>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container">
-    <h3><%= user_name_possessive %>  Cart</h3>
+  <h3><%= user_name_possessive %>  Cart</h3>
   <h6><%= link_to "Continue Shopping", items_path %></h6>
 
   <center>
@@ -15,9 +15,12 @@
           <th>Subtotal</th>
         </tr>
       </thead>
-      <tbody><% @items.each do |item, quantity| %>
-        <%= render partial: 'item', locals: { item: item, quantity: quantity } %>
-      </tbody><% end %>
+      
+      <tbody>
+        <% @items.each do |item, quantity| %>
+          <%= render partial: 'item', locals: { item: item, quantity: quantity } %>
+        <% end %>
+      </tbody>
     </table>
 
     <div class="total">

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -1,10 +1,7 @@
 <div class="container">
-  <% if current_user  %>
-    <h3> <%= current_user.first_name %>'s  Cart</h3>
-  <% else %>
-    <h3> Your Cart </h3>
-  <% end %>
+    <h3><%= user_name_possessive %>  Cart</h3>
   <h6><%= link_to "Continue Shopping", items_path %></h6>
+
   <center>
     <table class="table table-hover">
       <thead>
@@ -17,24 +14,12 @@
           <th></th>
           <th>Subtotal</th>
         </tr>
-        <tbody>
-
-          <% @items.each do |item, quantity| %>
-            <div class="item-#{item.id}">
-              <tr>
-                <th scope="row"><strong><%= link_to item.title, item_path(item) %></strong></th>
-                <td><%= image_tag item.image, :class => "cart_image"%></td>
-                <td>$<%= item.price %></td>
-                <td><%= quantity %></td>
-                <td><%= link_to "-", cart_path(id: item.id, condition: "decrease"), action: :update, method: :patch, class: "badge badge-danger" %>
-                <%= link_to "+", cart_path(id: item.id, condition: "increase"), action: :update, method: :patch, class: "badge badge-success" %></td>
-                <td><%= link_to "Remove", cart_path(id: item.id), method: :delete, class: "badge badge-danger" %></td>
-                <td>$<%= quantity * item.price %></td>
-              </tr>
-            </div>
-          <% end %>
-        </tbody>
+      </thead>
+      <tbody><% @items.each do |item, quantity| %>
+        <%= render partial: 'item', locals: { item: item, quantity: quantity } %>
+      </tbody><% end %>
     </table>
+
     <div class="total">
       <% sum = 0 %>
       <% @items.each do |item, quantity| %>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -6,7 +6,6 @@
   <% end %>
   <h6><%= link_to "Continue Shopping", items_path %></h6>
   <center>
-    <!-- <div class="col-10"> -->
     <table class="table table-hover">
       <thead>
         <tr>
@@ -43,14 +42,10 @@
       <% end %>
       <p><b>Total: <%= number_to_currency(sum) %></b></p>
     </div>
+
     <div class="checkout">
-      <% if current_user %>
-        <%= link_to "Checkout", new_order_path%>
-      <% else %>
-        <%= link_to "Login", login_path %> <br />
-        <%= link_to "Create new account", new_user_path %>
-      <% end %>
+      <%= checkout_tag %>
     </div>
-    <!-- </div> -->
+
   </center>
 </div>


### PR DESCRIPTION
#### What does  this PR do?
adds cart_helper.rb under apps/helpers, with these methods:
  in application_helper.rb:
    + login_tags -> will show the "login" and "create new account" options with a line break between them
    + user_name_possessive -> will show either "username's" or "your's"
  in cart_helper.rb:
    + checkout_tag -> will either show checkout button or the login_tags
each method can be passed the same options as any other built-in helper (like class: 'thisClass', etc)

app/views/carts now has _item.html.erb partial

styles for carts moved to application.scss (but should probably be but in carts.scss eventually, and should be refactored at some point to use scss better)

#### Where should the reviewer start?
#### How should this be manually tested?
RSpec green with the same styles

#### Any background context you want to provide?
the partial _item.html.erb still needs a cart(or order) presenter object to get the total, sums are still wonky

#### What are the relevant story numbers?
#153574855

#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran? -> No
  - Do Environment Variables need to be set? -> No
  - Any other deploy steps? -> No

