### PR TITLE
Admin dashboard index

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,7 +2,7 @@ class Admin::DashboardController < ApplicationController
   before_action :require_admin
 
   def index
-    if params[:status] == "ordered" || params[:status] == "paid" || params[:status] == "cancelled" || params[:status] == "completed"
+    if params[:status]
       @orders = Order.filter_by_status(params[:status])
     else
       @orders = Order.all

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -3,7 +3,7 @@ class Admin::DashboardController < ApplicationController
 
   def index
     if params[:status]
-      @orders = Order.filter_by_status(params[:status])
+      @orders = Order.where(status: params[:status])
     else
       @orders = Order.all
     end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -7,6 +7,7 @@ class Admin::DashboardController < ApplicationController
     else
       @orders = Order.all
     end
+    @order_presenter = OrderPresenter.new
     flash[:notice] = "You're logged in as an Administrator."
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -10,7 +10,7 @@ module AdminHelper
   end
 
   def change_status_tag(order)
-    status ||= "paid" if order.status == "completed"
+    status ||= "paid" if order.status == "ordered"
     status ||= "completed" if order.status == "paid"
     if status
       link_to("Mark as #{status.capitalize}",

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,12 @@
+module AdminHelper
+
+  def cancel_tag(order)
+    if order.status == "paid" || order.status == "ordered"
+      link_to("Cancel",
+              order_path(order, status: "cancelled"),
+              method: :put,
+              class: "badge badge-warning")
+    end
+  end
+
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -9,4 +9,15 @@ module AdminHelper
     end
   end
 
+  def change_status_tag(order)
+    status ||= "paid" if order.status == "completed"
+    status ||= "completed" if order.status == "paid"
+    if status
+      link_to("Mark as #{status.capitalize}",
+              order_path(order, status: status),
+              method: :put,
+              class: "badge badge-success")
+    end
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -29,10 +29,6 @@ class Order < ApplicationRecord
     group(:status).count
   end
 
-  def self.filter_by_status(status)
-    where(status: status)
-  end
-
   def self.count_of_completed_orders
     where(status: :completed).count
   end

--- a/app/presenters/order_presenter.rb
+++ b/app/presenters/order_presenter.rb
@@ -1,0 +1,7 @@
+class OrderPresenter
+  
+  def statuses
+    Order.pluck(:status).uniq
+  end
+
+end

--- a/app/views/admin/dashboard/_nav.html.erb
+++ b/app/views/admin/dashboard/_nav.html.erb
@@ -1,0 +1,6 @@
+<nav class="nav nav-tabs" id="myTab" role="tablist">
+  <%= link_to "View Orders", admin_dashboard_index_path, class: "nav-item nav-link active", id: "nav-home-tab" %>
+    <%= link_to "View Items", admin_items_path, class: "nav-item nav-link" %>
+    <%= link_to "Update Account", edit_user_path(current_user), class: "nav-item nav-link" %>
+    <%= link_to "View Analytics", admin_analytics_path, class: "nav-item nav-link" %>
+</nav>

--- a/app/views/admin/dashboard/_order_filter.html.erb
+++ b/app/views/admin/dashboard/_order_filter.html.erb
@@ -2,14 +2,15 @@
   <div class="tab-pane fade show active" id="nav-home">
     <div id="right">
       <div class="dropdown">
+
         <button class="badge badge-danger dropdown-toggle" id="dropdownMenu1" data-toggle="dropdown">
           Filter Orders
           <span class="caret"></span>
         </button>
 
         <ul class="dropdown-menu">
-          <% Order.count_by_status.each do |status, count| %>
-          <li><%= link_to status.capitalize, admin_dashboard_index_path(status: status) %></li>
+          <% @order_presenter.statuses.each do |status| %>
+            <li><%= link_to status.capitalize, admin_dashboard_index_path(status: status) %></li>
           <% end %>
           <li><%= link_to 'View all', admin_dashboard_index_path %></li>
         </ul>

--- a/app/views/admin/dashboard/_order_filter.html.erb
+++ b/app/views/admin/dashboard/_order_filter.html.erb
@@ -1,0 +1,22 @@
+<div class="tab-content" id="nav-tabContent">
+  <div class="tab-pane fade show active" id="nav-home">
+    <div id="right">
+      <div class="dropdown">
+        <button class="badge badge-danger dropdown-toggle" id="dropdownMenu1" data-toggle="dropdown">
+          Filter Orders
+          <span class="caret"></span>
+        </button>
+
+        <ul class="dropdown-menu">
+          <% Order.count_by_status.each do |status, count| %>
+          <li><%= link_to status.capitalize, admin_dashboard_index_path(status: status) %></li>
+          <% end %>
+          <li><%= link_to 'View all', admin_dashboard_index_path %></li>
+        </ul>
+      </div>
+    </div>
+
+ 		<%= link_to "All Orders", admin_dashboard_index_path, class: "badge badge-success" %>
+ 		<%= link_to "All Items", admin_items_path, class: "badge badge-success" %>
+  </div>
+</div>

--- a/app/views/admin/dashboard/_order_row.html.erb
+++ b/app/views/admin/dashboard/_order_row.html.erb
@@ -1,0 +1,9 @@
+<tr class="order-<%= order.id %>">
+  <th scope="row">
+    <%= link_to order.id, order_path(order) %>
+  </th>
+  <td><%= order.date %></td>
+  <td class="status"><%= order.status.capitalize %></td>
+  <td><%= cancel_tag(order) %></td>
+  <td><%= change_status_tag(order) %></td>
+</tr>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -22,15 +22,7 @@
 
     <tbody>
       <% @orders.each do |order| %>
-        <tr class="order-<%= order.id %>">
-          <th scope="row">
-            <%= link_to order.id, order_path(order) %>
-          </th>
-          <td><%= order.date %></td>
-          <td class="status"><%= order.status.capitalize %></td>
-          <td><%= cancel_tag(order) %></td>
-          <td><%= change_status_tag(order) %></td>
-        </tr>
+        <%= render partial: 'order_row', locals: { order: order} %>
       <% end %>
     </tbody>
   </table>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -8,37 +8,31 @@
     <%= render partial: 'order_filter' %>
 
   </div>
- 	      <table class="table table-hover">
- 	         <thead>
- 	            <tr>
-         	      <th>Order #</th>
-         	      <th>Order Placed</th>
-         	      <th>Order Status</th>
- 		      			<th></th>
- 		      			<th></th>
- 	            </tr>
- 	          </thead>
-             <tbody>
-               <% @orders.each do |order| %>
-                 <tr class="order-<%= order.id %>">
-                   <th scope="row">
-                     <%= link_to order.id, order_path(order) %>
-                   </th>
-                   <td><%= order.date %></td>
-                   <td class="status"><%= order.status.capitalize %></td>
-                   <td><%= cancel_tag(order) %></td>
-                   <% if order.status == "ordered" %>
-                     <td><%= link_to "Mark as Paid", order_path(order, status: "paid"), method: :put, class: "badge badge-success" %></td>
-                   <% elsif order.status == "paid" %>
-                     <td><%= link_to "Mark as Completed", order_path(order, status: "completed"), method: :put, class: "badge badge-success" %></td>
-                   <% else %>
-                     <td></td>
-                   <% end %>
-                 </tr>
-             <% end %>
-           </tbody>
-       </table>
-     </div>
-    </div>
-  </div>
+
+ 	<table class="table table-hover">
+ 	  <thead>
+ 	    <tr>
+        <th>Order #</th>
+        <th>Order Placed</th>
+        <th>Order Status</th>
+ 		    <th></th>
+ 		    <th></th>
+ 	    </tr>
+ 	  </thead>
+
+    <tbody>
+      <% @orders.each do |order| %>
+        <tr class="order-<%= order.id %>">
+          <th scope="row">
+            <%= link_to order.id, order_path(order) %>
+          </th>
+          <td><%= order.date %></td>
+          <td class="status"><%= order.status.capitalize %></td>
+          <td><%= cancel_tag(order) %></td>
+          <td><%= change_status_tag(order) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
 </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -40,8 +40,5 @@
        </table>
      </div>
     </div>
-    <div class="tab-pane fade" id="nav-profile" role="tabpanel" aria-labelledby="nav-profile-tab">...</div>
-    <div class="tab-pane fade" id="nav-dropdown1" role="tabpanel" aria-labelledby="nav-dropdown1-tab">...</div>
-    <div class="tab-pane fade" id="nav-dropdown2" role="tabpanel" aria-labelledby="nav-dropdown2-tab">...</div>
   </div>
 </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -26,7 +26,7 @@
                    </th>
                    <td><%= order.date %></td>
                    <td class="status"><%= order.status.capitalize %></td>
-                   <td><%= link_to "Cancel", order_path(order, status: "cancelled"), method: :put, class: "badge badge-warning" if order.status == "paid" || order.status == "ordered" %></td>
+                   <td><%= cancel_tag(order) %></td>
                    <% if order.status == "ordered" %>
                      <td><%= link_to "Mark as Paid", order_path(order, status: "paid"), method: :put, class: "badge badge-success" %></td>
                    <% elsif order.status == "paid" %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -4,25 +4,10 @@
   <%= render partial: 'nav' %>
 
   <div class="container">
-  <div class="tab-content" id="nav-tabContent">
-    <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">
-      <div id="right">
-        <div class="dropdown">
-          <button class="badge badge-danger dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            Filter Orders
-            <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-            <% Order.count_by_status.each do |status, count| %>
-            <li><%= link_to status.capitalize, admin_dashboard_index_path(status: status) %></li>
-            <% end %>
-            <li role="separator" class="divider"></li>
-            <li><%= link_to 'View all', admin_dashboard_index_path %></li>
-          </ul>
-        </div>
-      </div>
- 			 <!-- <%= link_to "All Orders", admin_dashboard_index_path, class: "badge badge-success" %>
- 			 <%= link_to "All Items", admin_items_path, class: "badge badge-success" %> -->
+
+    <%= render partial: 'order_filter' %>
+
+  </div>
  	      <table class="table table-hover">
  	         <thead>
  	            <tr>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,13 +1,8 @@
 <div class="container">
   <h3>Admin Dashboard</h3>
-  <nav class="nav nav-tabs" id="myTab" role="tablist">
-    <a class="nav-item nav-link active" id="nav-home-tab" data-toggle="tab" href="#nav-home" role="tab" aria-controls="nav-home" aria-expanded="true">View Orders</a>
-    <%= link_to "View Items", admin_items_path, class: "nav-item nav-link" %>
-    <%= link_to "Update Account", edit_user_path(current_user), class: "nav-item nav-link" %>
-    <%= link_to "View Analytics", admin_analytics_path, class: "nav-item nav-link" %>
 
-    </div>
-  </nav>
+  <%= render partial: 'nav' %>
+
   <div class="container">
   <div class="tab-content" id="nav-tabContent">
     <div class="tab-pane fade show active" id="nav-home" role="tabpanel" aria-labelledby="nav-home-tab">

--- a/spec/models/orders_spec.rb
+++ b/spec/models/orders_spec.rb
@@ -80,25 +80,5 @@ RSpec.describe Order do
       expect(Order.count_by_status).to eq(status_count)
     end
 
-    it "can filter by status" do
-      ordered   = create(:order, status: "ordered")
-      paid_1    = create(:order, status: "paid")
-      paid_2    = create(:order, status: "paid")
-      cancelled = create(:order, status: "cancelled")
-
-      all_ordered   = Order.filter_by_status("ordered")
-      all_paid      = Order.filter_by_status("paid")
-      all_cancelled = Order.filter_by_status("cancelled")
-
-      expect(all_ordered).to include(ordered)
-      expect(all_ordered.count).to eq(1)
-
-      expect(all_paid).to include(paid_1)
-      expect(all_paid).to include(paid_2)
-      expect(all_paid.count).to eq(2)
-
-      expect(all_cancelled).to include(cancelled)
-      expect(all_cancelled.count).to eq(1)
-    end
   end
 end


### PR DESCRIPTION
#### What does  this PR do?
refactors the admin dashboard index page into partials and adds:
+ cancel_tag(order) -> adds a link for an admin to cancel an order
+ change_status_tag(order) -> changes status if the status is "ordered" or "paid
+ order presenter (can be extended)
and removes:
+ Order.filter_by_status (because why)

#### Where should the reviewer start?
#### How should this be manually tested?
#### Any background context you want to provide?
#### What are the relevant story numbers?
#### Screenshots (if appropriate)
#### Questions:
  - Do Migrations Need to be ran?
  - Do Environment Variables need to be set?
  - Any other deploy steps?
 -> nope

