### PR TITLE
Allow user edits to not require updating password

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,7 +21,8 @@ class UsersController < ApplicationController
       redirect_to admin_dashboard_index_path
     elsif current_user != nil
       current_user.update(user_params)
-      redirect_to dashboard_index_path
+      redirect_to account_edit_path
+      flash[:success] = "Successfully Updated Your Account Information"
     else
       render file: "/public/404"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,9 @@ Rails.application.routes.draw do
     resources :stores, only: [:index]
   end
 
-  resources :users ,    only: [:new, :create, :edit, :update]
+  resources :users, only: [:new, :create, :edit, :update]
+  get "/account/edit", to: "users#edit"
+
   resources :orders,    only: [:index, :new, :show, :update]
   resources :dashboard, only: [:index]
   resources :items,     only: [:index, :show]

--- a/spec/features/user/views/user_can_edit_their_information_without_having_to_change_their_password_spec.rb
+++ b/spec/features/user/views/user_can_edit_their_information_without_having_to_change_their_password_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 describe 'As a registered user, when i visit my account edit page' do
   before :each do
-    user = create(:user)
-    stub_logged_in_user(user)
+    @user = create(:user)
+    stub_logged_in_user(@user)
   end
+
   it 'i can edit my information withougt entering my password' do
     visit "/account/edit"
 
@@ -13,13 +14,10 @@ describe 'As a registered user, when i visit my account edit page' do
     click_on("Submit")
 
     expect(current_path).to eq("/account/edit")
-    expect(page).to have_content("George Oscar Bluth")
+
+    within("#user_first_name") do
+      expect(@user.first_name).to eq("George Oscar Bluth")
+    end
+    expect(page).to have_content("Successfully Updated Your Account Information")
   end
 end
-# As a logged in user
-# When I visit "/account/edit"
-# And I change my First Name to "George Oscar Bluth"
-# And I don't enter a password to edit my other data
-# And I click "Submit"
-# Then I should be on "/account/edit"
-# And I should see a my first name as "George Oscar Bluth"

--- a/spec/features/user/views/user_can_edit_their_information_without_having_to_change_their_password_spec.rb
+++ b/spec/features/user/views/user_can_edit_their_information_without_having_to_change_their_password_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe 'As a registered user, when i visit my account edit page' do
+  before :each do
+    user = create(:user)
+    stub_logged_in_user(user)
+  end
+  it 'i can edit my information withougt entering my password' do
+    visit "/account/edit"
+
+    fill_in "user[first_name]", with: "George Oscar Bluth"
+
+    click_on("Submit")
+
+    expect(current_path).to eq("/account/edit")
+    expect(page).to have_content("George Oscar Bluth")
+  end
+end
+# As a logged in user
+# When I visit "/account/edit"
+# And I change my First Name to "George Oscar Bluth"
+# And I don't enter a password to edit my other data
+# And I click "Submit"
+# Then I should be on "/account/edit"
+# And I should see a my first name as "George Oscar Bluth"

--- a/spec/features/user/views/user_visits_active_store_spec.rb
+++ b/spec/features/user/views/user_visits_active_store_spec.rb
@@ -1,0 +1,15 @@
+# require 'rails_helper'
+
+# describe "User visits an active stores show page" do
+#   before :each do
+#     store = create(:store)
+#   end
+#   it "they see a list of all the active items" do
+
+#   end
+# end
+
+# As a logged in user
+# When I visit "/vandelay-industries"
+# Then I should see a list of all active items for this store
+# And I should not see inactive items or items for other stores


### PR DESCRIPTION
#### What does  this PR do?
Allow user edits to not require updating password
#### How should this be manually tested?
visiting your account edit page as a logged in user and change your information
#### What are the relevant story numbers?
#153568626

#### Pivotal hook 
- [(Finishes|Fixes|Delivers) #153568626]
