### PR TITLE
Platform admin accepts store creation REDO

### DIFF
--- a/app/controllers/admin/stores_controller.rb
+++ b/app/controllers/admin/stores_controller.rb
@@ -1,4 +1,6 @@
 class Admin::StoresController < ApplicationController
+  before_action :authorize!
+
   def index
     @stores = delegate_stores
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,9 @@ class ApplicationController < ActionController::Base
     @user = User.find(session[:user_id]) if session[:user_id]
   end
 
-
   def current_admin?
     current_user && current_user.admin?
   end
-
 
   def set_cart
     @cart ||= Cart.new(session[:cart])
@@ -19,6 +17,11 @@ class ApplicationController < ActionController::Base
 
   def set_categories
     @categories = Category.all
+  end
+
+  def authorize!
+    current_permission = PermissionService.new(current_user, params[:controller], params[:action])
+    not_found unless current_permission.authorized?
   end
 
   private

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -3,6 +3,5 @@ class Role < ApplicationRecord
 
   has_many :user_role_stores
   has_many :stores, through: :user_role_stores
-  has_many :users, through: :user_role_stores
-
+  has_many :users,  through: :user_role_stores
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,16 @@ class User < ApplicationRecord
   has_many :orders
   has_many :user_role_stores
   has_many :stores, through: :user_role_stores
+  has_many :roles,  through: :user_role_stores
 
   validates :first_name, :last_name, :password, presence: true
   validates :email, presence: true, uniqueness: true
 
   enum role: ["default", "admin"]
+
+  def platform_admin?
+    roles.exists?(name: 'platform_admin')
+  end
 
   def full_name
     first_name + " " + last_name

--- a/app/models/user_role_store.rb
+++ b/app/models/user_role_store.rb
@@ -1,5 +1,5 @@
 class UserRoleStore < ApplicationRecord
   belongs_to :user
   belongs_to :role
-  belongs_to :store
+  belongs_to :store, optional: true
 end

--- a/app/services/permission_service.rb
+++ b/app/services/permission_service.rb
@@ -1,0 +1,19 @@
+class PermissionService
+  def initialize(user, controller, action)
+    @user       = user || User.new
+    @controller = controller
+    @action     = action
+
+    def authorized?
+      case
+      when user.platform_admin?
+        return true
+      else
+        return false
+      end
+    end
+  end
+
+  private
+    attr_reader :user, :controller, :action
+end

--- a/app/services/permission_service.rb
+++ b/app/services/permission_service.rb
@@ -7,7 +7,7 @@ class PermissionService
     def authorized?
       case
       when user.platform_admin?
-        return true
+        return true if controller == "admin/stores" && action.in?(%w(index show update))
       else
         return false
       end

--- a/db/migrate/20171213030316_add_plat_form_admin_to_user.rb
+++ b/db/migrate/20171213030316_add_plat_form_admin_to_user.rb
@@ -1,5 +1,0 @@
-class AddPlatFormAdminToUser < ActiveRecord::Migration[5.1]
-  def change
-     add_column :users, :platform_admin, :boolean, default: false
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213030316) do
+ActiveRecord::Schema.define(version: 20171212230650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,7 +93,6 @@ ActiveRecord::Schema.define(version: 20171213030316) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role", default: 0
-    t.boolean "platform_admin", default: false
   end
 
   add_foreign_key "items", "categories"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,6 +20,5 @@ FactoryBot.define do
     password   { Faker::SiliconValley.company }
     email      { Faker::SiliconValley.app }
     role       "admin"
-    platform_admin true
   end
 end

--- a/spec/features/platform_admin/admin_approves_pending_store_spec.rb
+++ b/spec/features/platform_admin/admin_approves_pending_store_spec.rb
@@ -1,16 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature "As a Platform admin " do
+  let!(:admin)          { create(:platform_admin) }
+  let!(:platform_admin) { Role.new(name: 'platform_admin') }
+  let!(:pending)        { create(:store, name: "Vandelay Industries") }
+  let!(:suspended)      { create(:store, name: "Innotech", status: 1) }
+  let!(:active)         { create(:store, name: "Bluth Company", status: 2) }
+  let!(:scrub_user)     { create(:user) }
+
   describe "When I visit admin/dashboard" do
-    let!(:admin)     { create(:platform_admin) }
-    let!(:pending)   { create(:store, name: "Vandelay Industries") }
-    let!(:suspended) { create(:store, name: "Innotech", status: 1) }
-    let!(:active)    { create(:store, name: "Bluth Company", status: 2) }
 
     before { login_user(admin.email, admin.password) }
 
     it "I see a stores and I can approve a pending store" do
       expect(current_path).to eq('/admin/dashboard')
+
+      admin.roles << platform_admin
 
       click_on "Stores"
 
@@ -28,6 +33,20 @@ RSpec.feature "As a Platform admin " do
 
       expect(current_path).to eq('/admin/stores')
       expect(page).to have_content('Active (2)')
+    end
+  end
+
+  describe "as a default user" do
+    before { login_user(scrub_user.email, scrub_user.password) }
+    it "i should receive status code 404 and a not found page" do
+       expect { visit '/admin/dashboard'}.to raise_error(ActionController::RoutingError)
+    end
+  end
+
+  describe "as a default admin user" do
+    before { login_user(admin.email, admin.password) }
+    it "i should receive status code 404 and a not found page" do
+       expect { visit '/admin/dashboard/stores'}.to raise_error(ActionController::RoutingError)
     end
   end
 end


### PR DESCRIPTION
#### What does  this PR do?
fixes platform admin store creation acceptance by introducing permissions and utilizing User.roles. Deletes old implementation which relied upon a platform_user boolean on the User table. Which, gross. Authorize! method now only accommodates for platform_admin and is only called in the admin stores controller. Will need to make this authorization ultra robust in the future. 

#### Where should the reviewer start?
permisison service, application controller, user model.
#### How should this be manually tested?
RSPEC.
#### What are the relevant story numbers?
FIXES #153568631
#### Questions:
  - Do Migrations Need to be ran?
YES
  - Do Environment Variables need to be set?
NO
  - Any other deploy steps?
NO
