### PR TITLE
deletes migration remove platform admin from users

### DIFF
--- a/db/migrate/20171217170728_remove_platform_admin_from_users.rb
+++ b/db/migrate/20171217170728_remove_platform_admin_from_users.rb
@@ -1,5 +1,0 @@
-class RemovePlatformAdminFromUsers < ActiveRecord::Migration[5.1]
-  def change
-    remove_column :users, :platform_admin, :boolean
-  end
-end


### PR DESCRIPTION
#### What does  this PR do?
RemovePlatformAdminFromUsers because AddPlatformAdminToUsers was never staged and so it broke migration. 